### PR TITLE
Implement single user mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3301,6 +3301,7 @@ dependencies = [
  "config",
  "jsonwebtoken",
  "once_cell",
+ "percent-encoding",
  "pulldown-cmark",
  "serde 1.0.126",
  "serde_yaml",

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ FROM debian:buster-slim as runtime
 RUN apt-get update && \
     apt-get install libssl1.1 -y --no-install-recommends
 
-COPY --from=builder /usr/app/target/release/tumblepub /usr/local/bin
+WORKDIR /usr/app
+RUN groupadd -g 999 tumblepub && \
+    useradd -r -u 999 -g tumblepub tumblepub
+COPY --chown=tumblepub:tumblepub --from=builder /usr/app/target/release/tumblepub .
+
+USER tumblepub
 EXPOSE 8080
-ENTRYPOINT ["/usr/local/bin/tumblepub"]
+ENTRYPOINT ["/usr/app/tumblepub"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Options are read in both via environment variables (with the prefix `TUMBLEPUB_`
 
 ```yaml
 # Enables/disables "single user" mode
+# If set to true, single_user options must also be set
+# Example:
+# single_user:
+#   username: "bob"
+#   email: "bob@example.com"
+#   password: "password"
 single_user_mode: true
 # The domain name this instance exists on
 local_domain: null

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -5,10 +5,9 @@ use tumblepub_utils::options::Options;
 pub mod models;
 
 pub async fn create_database_if_not_exists() -> Result<()> {
-  let db_name = Options::get().database().db_name();
-  let postgres_url = Options::get()
-    .database()
-    .database_url(Some("postgres".to_string()));
+  let database_opts = Options::get().database;
+  let db_name = database_opts.db_name.to_owned();
+  let postgres_url = database_opts.database_url(Some("postgres".to_string()));
 
   let mut conn = PgConnection::connect(&postgres_url).await?;
   let row = sqlx::query!(

--- a/crates/db/src/models/user.rs
+++ b/crates/db/src/models/user.rs
@@ -21,15 +21,23 @@ pub struct User {
 }
 
 #[derive(Debug)]
-pub struct InsertableUser {
+pub struct NewUser {
   pub email: String,
   pub password: String,
   pub primary_blog: i64,
 }
 
 impl User {
+  pub async fn count(conn: &mut PgConnection) -> Result<i64> {
+    let record = sqlx::query!(r#"SELECT COUNT(*) as "count!" FROM users"#)
+      .fetch_one(conn)
+      .await?;
+
+    Ok(record.count)
+  }
+
   /// Creates a new user and returns it
-  pub async fn create(conn: &mut PgConnection, model: InsertableUser) -> Result<User> {
+  pub async fn create(conn: &mut PgConnection, model: NewUser) -> Result<User> {
     // step 1: we salt our hashbrowns
     let salt: String = {
       use rand::Rng;

--- a/crates/db/src/models/user_blogs.rs
+++ b/crates/db/src/models/user_blogs.rs
@@ -22,4 +22,25 @@ SELECT EXISTS(SELECT 1 FROM user_blogs WHERE user_id = $1 AND blog_id = $2) AS "
 
     Ok(record.exists)
   }
+
+  pub async fn create_new(
+    conn: &mut PgConnection,
+    user_id: i64,
+    blog_id: i64,
+    is_admin: Option<bool>,
+  ) -> Result<()> {
+    sqlx::query!(
+      r#"
+INSERT INTO user_blogs (user_id, blog_id, is_admin)
+VALUES ($1, $2, $3)
+      "#,
+      user_id,
+      blog_id,
+      is_admin
+    )
+    .execute(conn)
+    .await?;
+
+    Ok(())
+  }
 }

--- a/crates/graphql/src/mutation/mod.rs
+++ b/crates/graphql/src/mutation/mod.rs
@@ -16,7 +16,7 @@ use super::models::user::UserAuthPayload;
 use crate::models::posts::{Post, PostInput};
 
 mod login;
-mod register;
+pub mod register;
 
 pub struct Mutation;
 #[Object]
@@ -37,7 +37,8 @@ impl Mutation {
     password: String,
     name: String,
   ) -> Result<UserAuthPayload> {
-    register(context, email, password, name).await
+    let pool = context.data::<PgPool>()?;
+    register(pool, email, password, name).await
   }
 
   pub async fn create_post(

--- a/crates/graphql/src/mutation/mod.rs
+++ b/crates/graphql/src/mutation/mod.rs
@@ -9,7 +9,7 @@ use tumblepub_db::models::{
   user::User,
   user_blogs::UserBlogs,
 };
-use tumblepub_utils::{errors::TumblepubError, jwt::Token};
+use tumblepub_utils::{errors::TumblepubError, jwt::Token, options::Options};
 
 use self::{login::login, register::register};
 use super::models::user::UserAuthPayload;
@@ -37,6 +37,10 @@ impl Mutation {
     password: String,
     name: String,
   ) -> Result<UserAuthPayload> {
+    if Options::get().single_user_mode {
+      return Err(TumblepubError::BadRequest("Registration has been disabled.").extend());
+    }
+
     let pool = context.data::<PgPool>()?;
     register(pool, email, password, name).await
   }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0"
 config = { version = "0.11", features = ["yaml"] }
 jsonwebtoken = "7.2"
 once_cell = "1.7"
+percent-encoding = "2.1"
 pulldown-cmark = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"

--- a/crates/utils/src/options/database.rs
+++ b/crates/utils/src/options/database.rs
@@ -1,3 +1,4 @@
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -28,7 +29,7 @@ impl DatabaseOptions {
     format!(
       "postgres://{}:{}@{}:{}/{}",
       database.username,
-      database.password,
+      utf8_percent_encode(&database.password, NON_ALPHANUMERIC).to_string(),
       database.hostname,
       database.port,
       db_name.unwrap_or(database.db_name,)

--- a/crates/utils/src/options/database.rs
+++ b/crates/utils/src/options/database.rs
@@ -2,11 +2,11 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DatabaseOptions {
-  db_name: String,
-  hostname: String,
-  port: i32,
-  username: String,
-  password: String,
+  pub db_name: String,
+  pub hostname: String,
+  pub port: i32,
+  pub username: String,
+  pub password: String,
 }
 
 impl Default for DatabaseOptions {
@@ -33,9 +33,5 @@ impl DatabaseOptions {
       database.port,
       db_name.unwrap_or(database.db_name,)
     )
-  }
-
-  pub fn db_name(&self) -> String {
-    self.db_name.to_owned()
   }
 }

--- a/crates/utils/src/options/mod.rs
+++ b/crates/utils/src/options/mod.rs
@@ -5,9 +5,10 @@ use config::{Config, ConfigError, Environment, File, FileFormat};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
-use self::database::DatabaseOptions;
+use self::{database::DatabaseOptions, single_user::SingleUserOptions};
 
 mod database;
+mod single_user;
 
 static OPTIONS_LOCATION: &str = "./options.yml";
 static OPTIONS: Lazy<RwLock<Options>> =
@@ -15,9 +16,10 @@ static OPTIONS: Lazy<RwLock<Options>> =
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Options {
-  single_user_mode: bool,
-  local_domain: String,
-  database: DatabaseOptions,
+  pub single_user_mode: bool,
+  pub local_domain: String,
+  pub database: DatabaseOptions,
+  pub single_user: Option<SingleUserOptions>,
 }
 
 impl Default for Options {
@@ -26,6 +28,7 @@ impl Default for Options {
       single_user_mode: true,
       local_domain: String::from("example.com"),
       database: DatabaseOptions::default(),
+      single_user: None,
     }
   }
 }
@@ -54,15 +57,5 @@ impl Options {
   /// Get a cloned `Options`.
   pub fn get() -> Self {
     OPTIONS.read().unwrap().to_owned()
-  }
-
-  pub fn single_user_mode(&self) -> bool {
-    self.single_user_mode
-  }
-  pub fn local_domain(&self) -> String {
-    self.local_domain.to_owned()
-  }
-  pub fn database(&self) -> DatabaseOptions {
-    self.database.to_owned()
   }
 }

--- a/crates/utils/src/options/single_user.rs
+++ b/crates/utils/src/options/single_user.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct SingleUserOptions {
+  pub username: String,
+  pub email: String,
+  pub password: String,
+}

--- a/migrations/20210520020325_fix_blog_unique_constraint.sql
+++ b/migrations/20210520020325_fix_blog_unique_constraint.sql
@@ -1,0 +1,8 @@
+-- remove the bad constraint
+ALTER TABLE blogs
+  DROP CONSTRAINT blogs_name_domain_key;
+
+-- add unique index, and also ensure domain is never ''
+CREATE UNIQUE INDEX blogs_name_domain_idx ON blogs (name, COALESCE(domain, ''));
+ALTER TABLE blogs
+  ADD CONSTRAINT blogs_empty_domain_check CHECK (domain <> '');

--- a/src/routes/activitypub/mod.rs
+++ b/src/routes/activitypub/mod.rs
@@ -25,7 +25,7 @@ pub async fn get_ap_blog(
     .await
     .expect("could not retrieve blog from db");
 
-  let local_domain = Options::get().local_domain();
+  let local_domain = Options::get().local_domain;
   if let Some(blog) = blog {
     Ok(Either::A(ActivityStreams(json!({
       "@context": "https://www.w3.org/ns/activitystreams",

--- a/src/routes/well_known/webfinger.rs
+++ b/src/routes/well_known/webfinger.rs
@@ -70,7 +70,7 @@ pub async fn webfinger(
   let domain = captures.get(2).map_or("", |c| c.as_str()).to_string();
 
   // we don't gotta deal with any domains that aren't ours
-  let local_domain = Options::get().local_domain();
+  let local_domain = Options::get().local_domain;
   if domain != local_domain {
     return Ok(HttpResponse::NotFound().finish());
   }


### PR DESCRIPTION
This PR implements single user mode. This mode allows an initial user account to be made on first run, and prevents any additional users from registering. It also hosts the primary blog of the first user on the root page.

Resolves #5.